### PR TITLE
development: fix pipeline.yml resource name

### DIFF
--- a/development/pipeline.yml
+++ b/development/pipeline.yml
@@ -16,7 +16,7 @@ resources:
 jobs:
 - name: hello-world-job
   plan:
-  - get: aosp-kernel
+  - get: aosp-tools
   - task: hello-world-task
     config:
       platform: linux


### PR DESCRIPTION
It was still named aosp-kernel.

Rename it to aosp-tools to match the README update done in e3b0522a91b8

Fixes: e3b0522a91b8 ("README: fix development resource check command")
Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>