### PR TITLE
.github: add python-flake8 action

### DIFF
--- a/.github/workflows/python-flake8.yml
+++ b/.github/workflows/python-flake8.yml
@@ -1,0 +1,17 @@
+name: flake8 Lint
+
+on: [pull_request]
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2


### PR DESCRIPTION
This way, flake8 will always be ran on pull requests.

This comes from [1]

[1] https://github.com/marketplace/actions/python-flake8-lint
Fixes https://github.com/makohoek/repo-resource/issues/9
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>