### PR TITLE
HACK: common: SourceConfiguration: force gitlab URLs to end with .git

### DIFF
--- a/repo_resource/common.py
+++ b/repo_resource/common.py
@@ -14,6 +14,7 @@ import warnings
 from contextlib import redirect_stdout
 from pathlib import Path
 from typing import NamedTuple
+from urllib.parse import urlparse
 
 import ssh_agent_setup
 from repo import manifest_xml
@@ -59,6 +60,12 @@ def source_config_from_payload(payload):
         raise RuntimeError('manifest url is mandatory')
 
     p = SourceConfiguration(**payload['source'])
+    source_url = urlparse(p.url)
+
+    if source_url.netloc == 'gitlab.com' and \
+       (source_url.scheme == 'http' or source_url.scheme == 'https'):
+        if not source_url.path.endswith('.git'):
+            raise RuntimeError('gitlab http(s) urls must end with .git')
 
     return p
 


### PR DESCRIPTION
When using an https url from gitlab without suffixing with .git,
`repo._Main(['sync'])` behaves poorly.
In fact, it generates bogus caracters on stdout, confusing concourse's
version result.

For example, using the following source.url:
https://gitlab.com/baylibre/ti/android/aosp/manifest.git

And run check-resource:
```
$ fly -t tutorial check-resource -r <resource-name>
```

generates:
```
> repo sync has finished successfully.
> Saved manifest to /tmp/tmpc2c992oc/manifest_snapshot
> run check: invalid character 'w' looking for beginning of value
> errored
```

If we replace this `source.url` by:
https://gitlab.com/baylibre/ti/android/aosp/manifest.git

we get:
```
> repo sync has finished successfully.
> Saved manifest to /tmp/tmplxohyvau/manifest_snapshot
> succeeded
```

So, using `.git` as a suffix does not trigger this (subtle) bug.

As a work-around, bail out early when detecting gitlab http/https
urls that do not have the `.git` suffix.

Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>