### PR TITLE
common: repo: use --force-sync for all sync operations

### DIFF
--- a/repo_resource/common.py
+++ b/repo_resource/common.py
@@ -156,7 +156,7 @@ class Repo:
                     repo._Main([
                         '--no-pager', 'sync', '--verbose',
                         '--current-branch', '--detach', '--no-tags',
-                        '--fail-fast'
+                        '--fail-fast', '--force-sync'
                     ])
                 else:
                     with tempfile.TemporaryDirectory() as tmpdir:
@@ -166,7 +166,7 @@ class Repo:
                             '--no-pager', 'sync', '--verbose',
                             '--current-branch', '--detach', '--no-tags',
                             '--fail-fast', '--manifest-name',
-                            tmp_manifest
+                            tmp_manifest, '--force-sync'
                         ])
         except Exception as e:
             raise (e)


### PR DESCRIPTION
For each resource, it might be possible that we start from a cache. In
that case, if network errors occured during the previous sync, we might
end up with a "partial synced repo".

When running a new sync on a partial synced repo, we can get various git
errors such as:
```
fatal: unable to read tree 1bd30c550e07938c0341639d02d4c66e90aba770
error: Cannot checkout <PROJECT_NAME>
error: Unable to fully sync the tree.
error: Checking out local projects failed.
```

Takes such partial syncs into account by passing --force-sync in sync().

Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>