### PR TITLE
common: pass --quiet in repo.init()

### DIFF
--- a/repo_resource/common.py
+++ b/repo_resource/common.py
@@ -143,11 +143,14 @@ class Repo:
             # Concourse expects every logs to be emitted to stderr:
             # https://concourse-ci.org/implementing-resource-types.html#implementing-resource-types
             with redirect_stdout(sys.stderr):
+                print('Downloading manifest from {}'.format(url))
                 repo._Main([
-                    '--no-pager', 'init', '--manifest-url', url,
+                    '--no-pager', 'init', '--quiet', '--manifest-url', url,
                     '--manifest-branch', revision, '--manifest-name', name,
                     '--depth=1', '--no-tags'
                 ])
+                print('repo has been initialized in {}'.format(self.__workdir))
+
         except Exception as e:
             raise (e)
         finally:


### PR DESCRIPTION
The repo command prints quite some information.
Some of that is printed to stderr and some is to stdout.

In the case of concourse, we *MUST NOT* print anything to stdout because
stdout is used for result of check() or get():

> run check: invalid character 'W' looking for beginning of value
> errored

For most of the printing, we can use `redirect_stdout(sys.stderr)` to
redirect stdout to stderr.

However, `redirect_stdout()` does not handle subprocesses [1]:
>  It also has no effect on the output of subprocesses.

Repo init uses subprocesses via:
```
m.Sync_NetworkHalf()
  _RemoteFetch()
    gitcmd = GitCommmand()
      p = subprocess.Popen()
```

Passing `--quiet` to "repo init" allows the GitCommand subprocess stdout
to be captured and thus not break concourse.

Print still some information to the user so that we still have some
feedback while "repo init" is ran.

[1] https://docs.python.org/3/library/contextlib.html#contextlib.redirect_stdout
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>