### PR TITLE
common: add depth argument for optional shallow cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Track changes in a [repo](https://gerrit.googlesource.com/git-repo/+/master/#rep
       -----END RSA PRIVATE KEY-----
     ```
 
+* `depth`: *Optional.* shallow clone with a history truncated to the specified number of commits.
+    Defaults to full git clone for each project.
+
 ### Example
 
 Resource configuration for a public project using repo (Android)

--- a/repo_resource/check.py
+++ b/repo_resource/check.py
@@ -38,7 +38,7 @@ def check(instream) -> list:
 
     repo = common.Repo()
 
-    repo.init(config.url, config.revision, config.name)
+    repo.init(config.url, config.revision, config.name, depth=1)
     repo.sync()
     version = repo.currentVersion()
 

--- a/repo_resource/in_.py
+++ b/repo_resource/in_.py
@@ -38,7 +38,7 @@ def in_(instream, dest_dir='.'):
 
     repo = common.Repo(workdir=Path(dest_dir))
 
-    repo.init(config.url, config.revision, config.name)
+    repo.init(config.url, config.revision, config.name, config.depth)
     repo.sync(requested_version)
     fetched_version = repo.currentVersion()
 


### PR DESCRIPTION
As of today, all CHECK/IN operations do shallow cloning for repo init
and repo sync. This saves lots of bandwidth and thus reduces build time
in general.

For CHECK, it always makes sense to do a shallow (depth=1) clone because
we just need to retrieve the version.

For GET, it might be interesting to have a full clone because we might
want to run "git push" operations from a repo that we retrieved via GET.

Add an optional "depth" argument to resource.

NOTE: this changes the default behaviour (which was depth=1 by default)
so pipelines need to be adapted if they want the same fetch speed.

Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>