### PR TITLE
in: fix duplicate remove_private_key_from_agent call

### DIFF
--- a/repo_resource/in_.py
+++ b/repo_resource/in_.py
@@ -54,9 +54,6 @@ def in_(instream, dest_dir='.'):
 
     metadata = repo.metadata()
 
-    if config.private_key != '_invalid':
-        common.remove_private_key_from_agent()
-
     return {"version": {"version": str(fetched_version)},
             "metadata": metadata}
 


### PR DESCRIPTION
We should never call remove_private_key_from_agent() twice because it generates the following python splash:

    in_.in_(instream, str(common.CACHEDIR))
  File "/root/repo_resource/in_.py", line 58, in in_
    common.remove_private_key_from_agent()
  File "/root/repo_resource/common.py", line 54, in remove_private_key_from_agent
    ssh_agent_setup._kill_agent()
  File "/usr/local/lib/python3.10/site-packages/ssh_agent_setup/__init__.py", line 13, in _kill_agent
    del os.environ['SSH_AUTH_SOCK']
  File "/usr/local/lib/python3.10/os.py", line 695, in __delitem__
    raise KeyError(key) from None
KeyError: 'SSH_AUTH_SOCK'

The removal was done properly for the get() but not for the in_() operation.

Add a smoke test to cover this and fix the duplicate remove call.

Fixes: bbb253c421a7 ("common: kill ssh_agent after check/_in operation")
Reported-by: Guillaume La Roque <glaroque@baylibre.com>
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>