### PR TITLE
check: use config.depth for repo init as well

### DIFF
--- a/repo_resource/check.py
+++ b/repo_resource/check.py
@@ -38,7 +38,7 @@ def check(instream) -> list:
 
     try:
         repo = common.Repo()
-        repo.init(config.url, config.revision, config.name, depth=1)
+        repo.init(config.url, config.revision, config.name, config.depth)
         repo.sync()
         version = repo.currentVersion()
     except Exception as e:


### PR DESCRIPTION
To optimize check time, we are *always* doing shallow clones in the check step, by passing depth=1 to repo init.

Unfortunetly, we cannot run shallow clones on dumb http endpoints, such as the ones used in openembedded:

$ /tmp/ git clone --depth=1 https://git.openembedded.org/meta-openembedded Cloning into 'meta-openembedded'...
fatal: dumb http transport does not support shallow capabilities

Respect the depth argument for check as well.

Note: this will (probably) slown down some CHECK operations. To minimize this, it's advised to use a depth argument for read-only repositories.

Reported-by: Sean McGannon <smcgannon@baylibre.com>
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>