### PR TITLE
Prevent checks from downloading whole repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Track changes in a [repo](https://gerrit.googlesource.com/git-repo/+/master/#rep
 * `jobs`: *Optional.* number of jobs to run in parallel (default: 0; based on number of CPU cores)
    Reduce this if you observe network errors.
 
+* `check_jobs`: for check step only: number of jobs to run in parallel (default: jobs\*2,
+  2 if jobs is undefined).
+
 ### Example
 
 Resource configuration for a public project using repo (Android)

--- a/repo_resource/check.py
+++ b/repo_resource/check.py
@@ -37,8 +37,11 @@ def check(instream) -> list:
         common.add_private_key_to_agent(config.private_key)
 
     try:
-        repo = common.Repo()
-        repo.init(config.url, config.revision, config.name, config.depth)
+        repo = common.Repo(config.url,
+                           config.revision,
+                           config.name,
+                           config.depth)
+        repo.init()
         repo.sync(jobs=config.jobs)
         version = repo.currentVersion()
     except Exception as e:

--- a/repo_resource/common.py
+++ b/repo_resource/common.py
@@ -160,7 +160,7 @@ class Repo:
         try:
             # Google's repo prints a lot of information to stdout.
             # Concourse expects every logs to be emitted to stderr:
-            # https://concourse-ci.org/implementing-resource-types.html#implementing-resource-types
+            # https://concourse-ci.org/implementing-resource-types.html#implementing-resource-types  # noqa: E501
             with redirect_stdout(sys.stderr):
                 repo_cmd = [
                     '--no-pager', 'init', '--quiet', '--manifest-url',

--- a/repo_resource/common.py
+++ b/repo_resource/common.py
@@ -12,6 +12,7 @@ import os
 import sys
 import tempfile
 import warnings
+import re
 
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -76,8 +77,10 @@ def source_config_from_payload(payload):
     p = SourceConfiguration(**payload['source'])
     source_url = urlparse(p.url)
 
-    if source_url.netloc == 'gitlab.com' and \
-       (source_url.scheme == 'http' or source_url.scheme == 'https'):
+    if (
+        source_url.netloc == 'gitlab.com' and
+        re.fullmatch('https?', source_url.scheme)
+       ):
         if not source_url.path.endswith('.git'):
             raise RuntimeError('gitlab http(s) urls must end with .git')
 

--- a/repo_resource/in_.py
+++ b/repo_resource/in_.py
@@ -37,9 +37,9 @@ def in_(instream, dest_dir='.'):
         common.add_private_key_to_agent(config.private_key)
 
     try:
-        repo = common.Repo(workdir=Path(dest_dir))
-
-        repo.init(config.url, config.revision, config.name, config.depth)
+        repo = common.Repo(config.url, config.revision,
+                           config.name, config.depth, workdir=Path(dest_dir))
+        repo.init()
         repo.sync(requested_version, config.jobs)
         fetched_version = repo.currentVersion()
     except Exception as e:

--- a/repo_resource/in_.py
+++ b/repo_resource/in_.py
@@ -33,6 +33,13 @@ def in_(instream, dest_dir='.'):
     config = common.source_config_from_payload(payload)
     requested_version = common.Version(payload['version']['version'])
 
+    # Check version is valid xml
+    common.Version(payload['version']['version']).standard()
+
+    standard_versions = []
+    for v in payload.get('versions', []):
+        standard_versions.append(common.Version(v['version']).standard())
+
     if config.private_key != '_invalid':
         common.add_private_key_to_agent(config.private_key)
 
@@ -41,7 +48,7 @@ def in_(instream, dest_dir='.'):
                            config.name, config.depth, workdir=Path(dest_dir))
         repo.init()
         repo.sync(requested_version, config.jobs)
-        fetched_version = repo.currentVersion()
+        repo.update_version()
     except Exception as e:
         raise e
     finally:
@@ -49,15 +56,12 @@ def in_(instream, dest_dir='.'):
         if config.private_key != '_invalid':
             common.remove_private_key_from_agent()
 
-    if fetched_version != requested_version:
-        raise RuntimeError('Could not fetch requested version')
-
     # save a copy of the manifest alongside the sources
     repo.save_manifest('.repo_manifest.xml')
 
     metadata = repo.metadata()
 
-    return {"version": {"version": str(fetched_version)},
+    return {"version": {"version": str(requested_version)},
             "metadata": metadata}
 
 

--- a/repo_resource/requirements.txt
+++ b/repo_resource/requirements.txt
@@ -1,2 +1,3 @@
 gitrepo==2.32.2
 ssh-agent-setup==2.0.1
+GitPython==3.1.31

--- a/repo_resource/requirements.txt
+++ b/repo_resource/requirements.txt
@@ -1,2 +1,2 @@
-gitrepo==2.31.1
+gitrepo==2.32.2
 ssh-agent-setup==2.0.1

--- a/repo_resource/test_check.py
+++ b/repo_resource/test_check.py
@@ -31,6 +31,12 @@ class TestCheck(unittest.TestCase):
                 'name': 'aosp_device_fixed.xml'
             }
         }
+        self.demo_manifests_source_norev = {
+            'source': {
+                'url': 'https://github.com/makohoek/demo-manifests.git',
+                'name': 'aosp_device_fixed.xml'
+            }
+        }
         self.demo_ssh_manifests_source = {
             'source': {
                 'url': 'https://github.com/makohoek/demo-manifests.git',
@@ -94,8 +100,7 @@ class TestCheck(unittest.TestCase):
             check.check(instream)
 
     def test_branch_defaults_to_HEAD(self):
-        no_revision_data = self.demo_manifests_source
-        no_revision_data['source']['revision'] = None
+        no_revision_data = self.demo_manifests_source_norev
         instream = StringIO(json.dumps(no_revision_data))
         check.check(instream)
 

--- a/repo_resource/test_in.py
+++ b/repo_resource/test_in.py
@@ -10,15 +10,12 @@ import shutil
 import unittest
 from pathlib import Path
 
-import repo
-
 from . import check
 from . import common
 from . import in_
 
 
 class TestIn(unittest.TestCase):
-
     def setUp(self):
         self.demo_manifests_source = {
             'source': {


### PR DESCRIPTION
Repo versions are computed from manifests with updated revisions for each project. The repo tool can only generate a manifest with accurate sha1 hashes once all projects have been downloaded locally (repo manifest -r -o new-manifest.xml). This uses a lot of network bandwith, memory, cpu and disk space and is a huge waste of time.
git ls-remote is used instead to fetch revisions much quicker before being injected into the original manifest. A new variable check_jobs is used to spawn concurrent processes to make it close to X times faster
Adjust jobs and check_jobs variables based on the git servers capabilities/limitations