### PR TITLE
common: tests: use assertEqual for python-3.12 compatibility

### DIFF
--- a/repo_resource/test_check.py
+++ b/repo_resource/test_check.py
@@ -251,7 +251,7 @@ YDbuygyhlR8C8AAAAObWFrb2hvZWtAZ3Jvb3QBAgMEBQ==
         with self.assertRaises(SystemExit):
             versions = check.check(instream)
 
-        self.assertEquals(len(versions), 0)
+        self.assertEqual(len(versions), 0)
 
     def test_ssh_private_key_without_manifest_access(self):
         data = self.demo_ssh_manifests_source
@@ -306,7 +306,7 @@ YDbuygyhlR8C8AAAAObWFrb2hvZWtAZ3Jvb3QBAgMEBQ==
         with self.assertRaises(SystemExit):
             versions = check.check(instream)
 
-        self.assertEquals(len(versions), 0)
+        self.assertEqual(len(versions), 0)
 
     # test that we can specify an amount of jobs
     # This is a little flaky because it depends on network

--- a/repo_resource/test_in.py
+++ b/repo_resource/test_in.py
@@ -69,7 +69,7 @@ class TestIn(unittest.TestCase):
         instream = StringIO(json.dumps(data))
         fetched_version = in_.in_(instream, str(common.CACHEDIR))
 
-        self.assertEquals(fetched_version['version'], data['version'])
+        self.assertEqual(fetched_version['version'], data['version'])
 
     def test_get_metadata(self):
         data = self.demo_manifests_source
@@ -82,8 +82,8 @@ class TestIn(unittest.TestCase):
         expected_project = 'device/generic/common'
         expected_revision = '033d50e2298811d81de7db8cdea63e349a96c9ba'
 
-        self.assertEquals(result['metadata'][0]['name'], expected_project)
-        self.assertEquals(result['metadata'][0]['value'], expected_revision)
+        self.assertEqual(result['metadata'][0]['name'], expected_project)
+        self.assertEqual(result['metadata'][0]['value'], expected_revision)
 
     @unittest.skipUnless(
         Path('development/ssh/test_key').exists(), "requires ssh test key")
@@ -115,4 +115,4 @@ class TestIn(unittest.TestCase):
             common.CACHEDIR / '.repo_manifest.xml')
         expected_manifest_version = common.Version(data['version']['version'])
 
-        self.assertEquals(saved_manifest_version, expected_manifest_version)
+        self.assertEqual(saved_manifest_version, expected_manifest_version)


### PR DESCRIPTION
On recent systems with python-3.12, the unit tests fail with a syntax error:
```
====================================================================== ERROR: test_get_metadata (repo_resource.test_in.TestIn.test_get_metadata) ---------------------------------------------------------------------- Traceback (most recent call last):
  File "/root/repo_resource/test_in.py", line 85, in test_get_metadata
    self.assertEquals(result['metadata'][0]['name'], expected_project)
    ^^^^^^^^^^^^^^^^^
AttributeError: 'TestIn' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
```
Fix it by using assertEqual instead of assertEquals.