### PR TITLE
Rewrite urls with insteadOf option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Track changes in a [repo](https://gerrit.googlesource.com/git-repo/+/master/#rep
 * `jobs`: *Optional.* number of jobs to run in parallel (default: 0; based on number of CPU cores)
    Reduce this if you observe network errors.
 
+* `rewrite`: *Optional.* Any URL that starts with this value will be rewritten with the give value.
+   Similar to git url insteadOf option.
+    Example: rewrite http(s):// to git://
+
+    ```yaml
+    rewrite:
+      "http://": "git://"
+      "https://": "git://"
+    ```
+
 * `check_jobs`: for check step only: number of jobs to run in parallel (default: jobs\*2,
   2 if jobs is undefined).
 

--- a/repo_resource/check.py
+++ b/repo_resource/check.py
@@ -48,10 +48,11 @@ def check(instream) -> list:
                            config.revision,
                            config.name,
                            config.depth)
-        repo.set_rewrite(config.rewrite) \
-            .init()
-        repo.update_manifest(jobs=check_jobs)
-        version = repo.currentVersion()
+        version = repo \
+            .set_rewrite(config.rewrite) \
+            .init() \
+            .update_manifest(jobs=check_jobs) \
+            .currentVersion()
     except Exception as e:
         raise e
     finally:

--- a/repo_resource/check.py
+++ b/repo_resource/check.py
@@ -48,7 +48,8 @@ def check(instream) -> list:
                            config.revision,
                            config.name,
                            config.depth)
-        repo.init()
+        repo.set_rewrite(config.rewrite) \
+            .init()
         repo.update_manifest(jobs=check_jobs)
         version = repo.currentVersion()
     except Exception as e:

--- a/repo_resource/common.py
+++ b/repo_resource/common.py
@@ -296,6 +296,7 @@ class Repo:
                 print('Downloading manifest from {}'.format(self.__url))
                 repo._Main(repo_cmd)
                 print('repo has been initialized in {}'.format(self.__workdir))
+            return self
 
         except Exception as e:
             raise (e)
@@ -323,6 +324,7 @@ class Repo:
                     repo._Main(repo_cmd)
                 if os.listdir(self.__workdir) == []:
                     raise Exception('Sync failed. Is manifest correct?')
+            return self
         except Exception as e:
             raise (e)
         finally:
@@ -340,6 +342,7 @@ class Repo:
             full_path = self.__workdir / filename
             print('Saving manifest to {}'.format(full_path))
             self.__version.to_file(full_path)
+        return self
 
     def currentVersion(self) -> Version:
         return self.__version
@@ -444,6 +447,7 @@ class Repo:
                         strip_text=True
                     )
                 )
+            return self
 
         except FileNotFoundError as e:
             with redirect_stdout(sys.stderr):

--- a/repo_resource/in_.py
+++ b/repo_resource/in_.py
@@ -46,7 +46,8 @@ def in_(instream, dest_dir='.'):
     try:
         repo = common.Repo(config.url, config.revision,
                            config.name, config.depth, workdir=Path(dest_dir))
-        repo.init()
+        repo.set_rewrite(config.rewrite) \
+            .init()
         repo.sync(requested_version, config.jobs)
         repo.update_version()
     except Exception as e:

--- a/repo_resource/in_.py
+++ b/repo_resource/in_.py
@@ -47,9 +47,9 @@ def in_(instream, dest_dir='.'):
         repo = common.Repo(config.url, config.revision,
                            config.name, config.depth, workdir=Path(dest_dir))
         repo.set_rewrite(config.rewrite) \
-            .init()
-        repo.sync(requested_version, config.jobs)
-        repo.update_version()
+            .init() \
+            .sync(requested_version, config.jobs) \
+            .update_version()
     except Exception as e:
         raise e
     finally:

--- a/repo_resource/test_check.py
+++ b/repo_resource/test_check.py
@@ -32,6 +32,18 @@ class TestCheck(unittest.TestCase):
                 'name': 'aosp_device_fixed.xml'
             }
         }
+        self.demo_manifests_to_rewrite_source = {
+            'source': {
+                'url':
+                'https://unreachable-github.com/makohoek/demo-manifests.git',
+                'revision': 'main',
+                'name': 'aosp_device_fixed.xml',
+                'rewrite': {
+                    'https://unreachable-github.com':
+                    'https://github.com'
+                },
+            },
+        }
         self.demo_manifests_source_norev = {
             'source': {
                 'url': 'https://github.com/makohoek/demo-manifests.git',
@@ -98,6 +110,11 @@ class TestCheck(unittest.TestCase):
         instream = StringIO(json.dumps(unreachable_data))
         with self.assertRaises(repo.error.GitError):
             check.check(instream)
+
+    def test_rewrite_manifest(self):
+        rewrite_url_data = self.demo_manifests_to_rewrite_source
+        instream = StringIO(json.dumps(rewrite_url_data))
+        check.check(instream)
 
     def test_unknown_revision(self):
         unknown_revision_data = self.aosp_platform_source


### PR DESCRIPTION
The insteadOf option gives the ability to easily rewrite git protocols or even urls.
It can be useful to pull repositories from a mirror.