### PR TITLE
check: Fix handling of <remove-project /> element

### DIFF
--- a/repo_resource/common.py
+++ b/repo_resource/common.py
@@ -355,6 +355,7 @@ class Repo:
 
     def update_manifest(self, jobs):
         projects = []
+        removed_projects = []
 
         jobs = jobs or DEFAULT_CHECK_JOBS
         self.__change_to_workdir()
@@ -378,6 +379,24 @@ class Repo:
                     defaultRemote = defaults.get('remote')
                     defaultBranch = defaults.get('revision') \
                         or self.__get_remote_revision(defaultRemote)
+
+                # Handle <remove-project /> element:
+                # - Should not be present in final XML (for version)
+                # - Should remove first matching project by name
+                for p in manifest.findall('remove-project'):
+                    project = p.get('name')
+                    removed_projects.append(project)
+                    manifest.remove(p)
+
+                for p in manifest.findall('project'):
+                    project = p.get('name')
+                    if project in removed_projects:
+                        manifest.remove(p)
+                        removed_projects.remove(project)
+                    # If there are no more projects to remove, we can
+                    # skip parsing the rest of the projects
+                    if not removed_projects:
+                        break
 
                 for p in manifest.findall('project'):
                     project = p.get('name')


### PR DESCRIPTION
When `repo-resource` creates a version string (which is a full XML representation of a manifest), the `<remove-project>` tag is not taken into account.
Because of this, we generate "false positives" for new Versions, which could trigger unwanted builds.

For example, with manifest [1], we see that the Version string has the device/amlogic/yukawa project twice, which is wrong.

Handle the <remove-project /> element to fix this.

[1] https://github.com/makohoek/demo-manifests/blob/main/aosp_remove_yukawa_project.xml
Fixes: https://github.com/makohoek/repo-resource/issues/36
Fixes: c23fc0c2fea1 ("Switch to getRevision code based on git ls-remote")
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>