### PR TITLE
common: git retry feature

### DIFF
--- a/repo_resource/requirements.txt
+++ b/repo_resource/requirements.txt
@@ -2,3 +2,4 @@ setuptools==74.1.2
 gitrepo==2.32.2
 ssh-agent-setup==2.0.1
 GitPython==3.1.31
+retrying==1.3.4


### PR DESCRIPTION
We may face some "too many requests" failures (429 error) with some servers. It's better to retry the failed git command on a single repo rather than restart the whole process later which is likely to fail again